### PR TITLE
CI integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+    - name: Setup Gradle
+      uses: gradle/gradle-build-action@v2
+    - name: Change wrapper permissions
+      run: chmod +x ./gradlew
+    - name: Execute Gradle build
+      run: ./gradlew build


### PR DESCRIPTION
Dodałem CI. Musimy się zastanowić, jaki będziemy mieć model pracy jeśli chodzi o Gita (o ile nie ustaliliście tego wcześniej). W tej chwili ustawiłem tak, że budowa jest uruchamiana przed pull requestem i przy dogrywaniu zmian do gałęzi `master` (domyślne ustawienia).

Przebieg budowy jest widoczny w zakładce `Actions`.

W kwestii opłat, to dla publicznych repozytoriów wszystko jest za darmo, więc nie musimy się tym przejmować.